### PR TITLE
[Issue 24] Dub build fails with -version=0.4.0 switch

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,7 +15,6 @@ and is the only one which is completely written in D.
 #Official Website:
 http://dgame-dev.de/ (http://rswhite.de/dgame4/)",
     "homepage":     "https://github.com/Dgame/Dgame",
-    "versions":     ["0.4.0"],
     "authors":  	["Randy Schütt"],
     "license":      "Zlib/PNG License",
     "sourcePaths":["."],


### PR DESCRIPTION
This removes the  "versions":"0.4.0" field from dub.json.  I've only tested on ArchLinux x86_64.

It's difficult to find the relevant information in the DUB docs but DUB passes each "versions" value to the compiler as a -version switch.