### PR TITLE
Fix error from incorrect use of versions: field in dub.json.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,7 +15,6 @@ and is the only one which is completely written in D.
 #Official Website:
 http://dgame-dev.de/ (http://rswhite.de/dgame4/)",
     "homepage":     "https://github.com/Dgame/Dgame",
-    "versions":     ["0.4.0"],
     "authors":  	["Randy Schütt"],
     "license":      "Zlib/PNG License",
     "sourcePaths":["."],


### PR DESCRIPTION
The "versions" field in dub.json takes whatever you give it and passes it to the compiler as a parameter to -version. It has nothing to do with specifying a version of Dgame -- that's what git tags are for. So "versions" ["0.4.0"] was causing dub to pass -version=0.4.0 to DMD. Since DMD does not accept floating point numbers as version levels, compilation errored out with:

```
Error: unrecognized switch '-version=0.4.0'
```
 This PR removes that line and eliminates the error.