### PR TITLE
Fixing Surface

### DIFF
--- a/source/Dgame/Graphic/Surface.d
+++ b/source/Dgame/Graphic/Surface.d
@@ -62,7 +62,7 @@ struct Surface {
         Blue  = 4, /// Blue Mask
         Alpha = 8  /// Alpha Mask
     }
-    
+
     version (LittleEndian) {
         enum uint RMask = 0x000000ff;
         enum uint GMask = 0x0000ff00;
@@ -241,7 +241,7 @@ public:
      * If it's null, the whole Surface is filled.
      */
     @nogc
-    void fill()(auto ref const Color col, const Rect* rect = null) nothrow {
+    void fill()(auto ref const Color4b col, const Rect* rect = null) nothrow {
         if (!_surface)
             return;
 

--- a/source/Dgame/Graphic/Surface.d
+++ b/source/Dgame/Graphic/Surface.d
@@ -63,14 +63,18 @@ struct Surface {
         Alpha = 8  /// Alpha Mask
     }
     
-    enum ubyte RMask = 0;
-    enum ubyte GMask = 0;
-    enum ubyte BMask = 0;
-    
-    version (LittleEndian)
+    version (LittleEndian) {
+        enum uint RMask = 0x000000ff;
+        enum uint GMask = 0x0000ff00;
+        enum uint BMask = 0x00ff0000;
         enum uint AMask = 0xff000000;
-    else
+    }
+    else {
+        enum uint RMask = 0xff000000;
+        enum uint GMask = 0x00ff0000;
+        enum uint BMask = 0x0000ff00;
         enum uint AMask = 0x000000ff;
+    }
 
 private:
     SDL_Surface* _surface;


### PR DESCRIPTION
It fixes Surface.fill() method and Surface color masks.

The following code doesn't work without fixing type of `col` argument of `fill()` method (changed from `Color` to `Color4b`). And it creates white PNG-file instead of transparent one without fixing masks.

```d
Surface test = Surface(64, 64);
test.fill(Color4b.White.withTransparency(0));
test.saveToFile("test.png");
```