### PR TITLE
Fixed transformation matrix

### DIFF
--- a/source/Dgame/Graphic/Transformable.d
+++ b/source/Dgame/Graphic/Transformable.d
@@ -66,8 +66,8 @@ final:
     @nogc
     ref const(Matrix4) getMatrix() pure nothrow {
         if (_was_transformed) {
-            const Vector2f global_center = _position + _local_center;
-            _matrix.loadIdentity().rotate(_rotation, global_center).scale(_scale, global_center).translate(_position);
+            const Vector2f global_center = _position - _local_center;
+            _matrix.loadIdentity().translate(global_center).rotate(_rotation, _local_center).scale(_scale, _local_center);
             _was_transformed = false;
         }
 


### PR DESCRIPTION
Here is how to test the fix. Add to the `source/Dgame/test/main.d` these lines:

```d
    Shape s1 = new Shape(Geometry.Quad, [Vertex(0, 0), Vertex(100, 0), Vertex(100, 100), Vertex(0, 100)]);
    s1.setColor(Color4b.Green);
    s1.setCenter(50, 50);
    s1.setRotation(45);
    s1.setPosition(240, 320);

    Shape s2 = new Shape(Geometry.Quad, [Vertex(0, 0), Vertex(50, 0), Vertex(50, 50), Vertex(0, 50)]);
    s2.setColor(Color4b.Blue);
    s2.setCenter(25, 25);
    s2.setPosition(240, 320);

    Shape s3 = new Shape(10, Vector2f(0, 0));
    s3.setColor(Color4b.Red);
    s3.setRotation(90);
    s3.setPosition(240, 320);

// within render loop

        wnd.draw(s1);
        wnd.draw(s2);
        wnd.draw(s3);
```

Without the fix you will get this. Shapes should be at the center of the window, but they actually not.
![before](https://cloud.githubusercontent.com/assets/961059/7436420/fac97434-f066-11e4-86c8-6fa457c5e945.png)

With the fix you will get this. 
![after](https://cloud.githubusercontent.com/assets/961059/7436419/fa93ca78-f066-11e4-9c4d-4b2660258a1e.png)
